### PR TITLE
fix(matcher): 無効なセレクターでの再ハイライトエラーを修正

### DIFF
--- a/denops/typescript-estree/classes/matcher.ts
+++ b/denops/typescript-estree/classes/matcher.ts
@@ -112,6 +112,8 @@ export default class Matcher {
       await this.focusNext();
     } catch (error) {
       console.error("Failed to highlight selector:", error);
+      // Reset selector on error to prevent re-highlighting an invalid one
+      this.#selector = "";
       await this.#denops.cmd(
         `echohl ErrorMsg | echo "Invalid selector: ${selector}" | echohl None`,
       );
@@ -125,8 +127,11 @@ export default class Matcher {
       await this.#highlightSelector(this.#selector);
     } catch (error) {
       console.error("Failed to re-highlight:", error);
+      const selector = this.#selector;
+      // Reset selector on error to prevent re-highlighting an invalid one
+      this.#selector = "";
       await this.#denops.cmd(
-        `echohl ErrorMsg | echo "Failed to re-highlight" | echohl None`,
+        `echohl ErrorMsg | echo "Invalid selector: ${selector}" | echohl None`,
       );
     }
   };

--- a/test_sample.ts
+++ b/test_sample.ts
@@ -1,0 +1,18 @@
+// test_sample.ts contains various patterns to test:
+interface User { // TSInterfaceDeclaration
+  id: number;
+  name: string;
+}
+
+function createUser() { // FunctionDeclaration
+  console.log("test"); // CallExpression[callee.object.name="console"]
+  var oldStyle = 1; // VariableDeclaration[kind="var"]
+  if (1 == 1) { // BinaryExpression[operator="=="]
+    return true;
+  }
+}
+
+const Component = () => { // ArrowFunctionExpression
+  const [state] = useState(); // CallExpression[callee.name="useState"]
+  return <div> Hello < /div>;    / / JSXElement;
+};


### PR DESCRIPTION
これまで、無効なセレクターでハイライトを実行すると、その無効なセレクターが内部に保存されていました。 これにより、`:TSESTreeReHighlight` を実行するたびにエラーが再発していました。

この修正では、`highlight` および `reHighlight` コマンドでセレクターが無効であるためにエラーが発生した場合に、保存されているセレクターをクリアするようにしました。 これにより、一度エラーが発生した後に、`reHighlight` コマンドで繰り返しエラーが表示されることがなくなります。

主な変更点:
- `highlight` メソッドの `catch` ブロックで、`this.#selector` をリセットします。
- `reHighlight` メソッドの `catch` ブロックでも同様に `this.#selector` をリセットし、エラーメッセージを `highlight` と一貫性のあるものに修正しました。