### PR TITLE
🧹 Caretaker: Deduplicate buffer state and AST management logic

### DIFF
--- a/denops/typescript-estree/classes/inspecter.ts
+++ b/denops/typescript-estree/classes/inspecter.ts
@@ -5,11 +5,10 @@ import { collect } from "jsr:@denops/std/batch";
 
 import {
   byteIndexToCharIndex,
-  checkCache,
-  fetchBufState,
-  updateCacheAst,
+  getOrFetchBufState,
+  getOrParseAst,
 } from "../lib/utils.ts";
-import { findNodesAtPosition, parseToAst } from "../lib/ast.ts";
+import { findNodesAtPosition } from "../lib/ast.ts";
 
 export default class Inspecter {
   #denops: Denops;
@@ -64,30 +63,15 @@ export default class Inspecter {
         fn.getcurpos(denops),
       ]) as [number, number, [number, number, number, number, number]];
 
-      let state = checkCache(bufnr, tick);
-      if (!state) {
-        state = await fetchBufState(this.#denops, bufnr, tick);
-      }
-
-      let ast = state.ast;
-      if (!ast) {
-        if (!state.code.trim()) {
-          await this.#denops.cmd(
-            `echohl WarningMsg | echo "Buffer is empty" | echohl None`,
-          );
-          return;
-        }
-        // Parse AST if missing
-        const newAst = parseToAst(state.code);
-        if (newAst) {
-          updateCacheAst(bufnr, tick, newAst);
-          ast = newAst;
-        }
-      }
+      const state = await getOrFetchBufState(this.#denops, bufnr, tick);
+      const ast = getOrParseAst(state);
 
       if (!ast) {
+        const message = !state.code.trim()
+          ? "Buffer is empty"
+          : "Failed to parse current buffer";
         await this.#denops.cmd(
-          `echohl WarningMsg | echo "Failed to parse current buffer" | echohl None`,
+          `echohl WarningMsg | echo "${message}" | echohl None`,
         );
         return;
       }

--- a/denops/typescript-estree/lib/utils.ts
+++ b/denops/typescript-estree/lib/utils.ts
@@ -63,13 +63,14 @@ export const updateCacheAst = (
   }
 };
 
-const ensureBufState = async (denops: Denops): Promise<CacheEntry> => {
-  // Optimization: Fetch bufnr and changedtick in a single RPC call
-  const [bufnr, tick] = await collect(denops, (denops) => [
-    fn.bufnr(denops),
-    fn.getbufvar(denops, "%", "changedtick"),
-  ]) as [number, number];
-
+/**
+ * Returns cached buffer state or fetches it if not present/outdated.
+ */
+export const getOrFetchBufState = async (
+  denops: Denops,
+  bufnr: number,
+  tick: number,
+): Promise<CacheEntry> => {
   const cache = checkCache(bufnr, tick);
   if (cache) {
     return cache;
@@ -78,28 +79,46 @@ const ensureBufState = async (denops: Denops): Promise<CacheEntry> => {
   return await fetchBufState(denops, bufnr, tick);
 };
 
+const ensureBufState = async (denops: Denops): Promise<CacheEntry> => {
+  // Optimization: Fetch bufnr and changedtick in a single RPC call
+  const [bufnr, tick] = await collect(denops, (denops) => [
+    fn.bufnr(denops),
+    fn.getbufvar(denops, "%", "changedtick"),
+  ]) as [number, number];
+
+  return await getOrFetchBufState(denops, bufnr, tick);
+};
+
 export const getCurrentBufCode = async (denops: Denops) => {
   const cache = await ensureBufState(denops);
   return cache.code;
 };
 
+/**
+ * Returns cached AST or parses it if missing.
+ */
+export const getOrParseAst = (state: CacheEntry): AstRoot | null => {
+  if (state.ast) {
+    return state.ast;
+  }
+
+  if (!state.code.trim()) {
+    return null;
+  }
+
+  const ast = parseToAst(state.code);
+  if (ast) {
+    updateCacheAst(state.bufnr, state.tick, ast as AstRoot);
+  }
+  return ast;
+};
+
 export const getCurrentBufAst = async (denops: Denops) => {
   try {
     const cache = await ensureBufState(denops);
-
-    if (cache.ast) {
-      return cache.ast;
-    }
-
-    const code = cache.code;
-    if (!code.trim()) {
+    const ast = getOrParseAst(cache);
+    if (!ast && !cache.code.trim()) {
       console.warn("Buffer is empty");
-      return null;
-    }
-
-    const ast = parseToAst(code);
-    if (ast) {
-      updateCacheAst(cache.bufnr, cache.tick, ast as AstRoot);
     }
     return ast;
   } catch (error) {


### PR DESCRIPTION
This refactoring improves internal code quality by deduplicating logic for fetching buffer states and parsing/caching ASTs.

- In `denops/typescript-estree/lib/utils.ts`, I've introduced `getOrFetchBufState` and `getOrParseAst` helper functions.
- In `denops/typescript-estree/classes/inspecter.ts`, the `inspect` method now uses these helpers, which significantly reduces boilerplate and improves readability without sacrificing the performance benefit of batched RPC calls.
- The `getCurrentBufAst` utility was also refactored to use these helpers, ensuring consistent state management across the plugin.

All tests passed, and behavior is preserved exactly.

---
*PR created automatically by Jules for task [2331181069512129199](https://jules.google.com/task/2331181069512129199) started by @ediezindell*